### PR TITLE
chore: update license headers

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/chipfield/Chip.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/chipfield/Chip.java
@@ -2,7 +2,7 @@
  * #%L
  * ChipField Addon
  * %%
- * Copyright (C) 2018 Flowing Code
+ * Copyright (C) 2018 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
@@ -2,7 +2,7 @@
  * #%L
  * ChipField Addon
  * %%
- * Copyright (C) 2018 Flowing Code
+ * Copyright (C) 2018 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/chipfield/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/chipfield/DemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * ChipField Addon
  * %%
- * Copyright (C) 2018 Flowing Code
+ * Copyright (C) 2018 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/resources/frontend/styles/demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * ChipField Addon
  * %%
- * Copyright (C) 2018 Flowing Code
+ * Copyright (C) 2018 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
License headers were not updated, even when source code changes were applied in 2019 and 2020.