### PR TITLE
fix: setting readonly still allows deleting chips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /package.json
 /package-lock.json
 /webpack.config.js
+/error-screenshots

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.version>9.4.15.v20190215</jetty.version>
+		<drivers.dir>${project.basedir}/drivers</drivers.dir>
     </properties>
 	
 	<organization>
@@ -125,6 +126,23 @@
 			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <version>1.3</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+	        <groupId>io.github.bonigarcia</groupId>
+	        <artifactId>webdrivermanager</artifactId>
+	        <version>4.3.1</version>
+	    	<scope>test</scope>
+    	</dependency>
 		<dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>
@@ -317,6 +335,95 @@
 				</plugins>
 			</build>
 		</profile>
+		
+		<profile>
+            <id>it</id>
+            <build>
+				<plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${jetty.version}</version>
+                        <configuration>
+                            <scanIntervalSeconds>0</scanIntervalSeconds>
+                            <supportedPackagings>
+                                <supportedPackaging>jar</supportedPackaging>
+                            </supportedPackagings>
+                            <stopKey>${project.artifactId}</stopKey>
+                            <stopPort>8081</stopPort>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>start-jetty</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop-jetty</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+
+                    <!-- Runs the integration tests (*IT) after the server is started -->
+				    <plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.22.2</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+						 	</execution>
+						</executions>
+						<configuration>
+							<trimStackTrace>false</trimStackTrace>
+                            <enableAssertions>true</enableAssertions>
+                            <systemPropertyVariables>
+                                <!-- Pass location of downloaded webdrivers to the tests -->
+                                <webdriver.chrome.driver>
+                                    ${webdriver.chrome.driver}
+                                </webdriver.chrome.driver>
+                            </systemPropertyVariables>
+                        </configuration>
+				    </plugin>
+				    					
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <!-- Since the view class is defined in test, after compilation
+                                copy it to the runtime classpath to ensure it gets visited by
+                                  vaadin-maven-plugin -->
+                                <id>copy-test-to-classes</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.testOutputDirectory}</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+		
     </profiles>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons.chipfield</groupId>
     <artifactId>chipfield-addon</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <name>ChipField Addon</name>
     <description>Integration of paper-chip for Vaadin 14 as a field</description>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
@@ -213,28 +213,40 @@ public class ChipField<T> extends AbstractField<ChipField<T>, List<T>>
 		return getElement().getProperty("closable", false);
 	}
 
+	/** @deprecated use {@link #setEnabled(boolean)} */
+	@Deprecated
 	public void setDisabled(boolean disabled) {
 		getElement().setProperty("disabled", disabled);
 	}
 
+	/** @deprecated use {@link #isEnabled()} */
+	@Deprecated
 	public boolean isDisabled() {
 		return getElement().getProperty("disabled", false);
 	}
 
+	/** @deprecated use {@link #setReadOnly()} */
+	@Deprecated
 	public void setReadonly(boolean readonly) {
-		getElement().setProperty("readonly", readonly);
+		setReadOnly(readonly);
 	}
 
+	/** @deprecated use {@link #isReadOnly()} */
+	@Deprecated
 	public boolean isReadonly() {
-		return getElement().getProperty("readonly", false);
+		return this.isReadonly();
 	}
 
+	/** @deprecated use {@link #setRequiredIndicatorVisible(boolean)} */
+	@Deprecated
 	public void setRequired(boolean required) {
 		getElement().setProperty("required", required);
 	}
 
+	/** @deprecated use {@link #isRequiredIndicatorVisible()} */
+	@Deprecated
 	public boolean isRequired() {
-		return getElement().getProperty("required", false);
+		return isRequiredIndicatorVisible();
 	}
 
 	public void setValidationPattern(String pattern) {

--- a/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/AbstractViewTest.java
@@ -1,0 +1,93 @@
+package com.flowingcode.vaadin.addons.chipfield.integration;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+import com.vaadin.testbench.ScreenshotOnFailureRule;
+import com.vaadin.testbench.TestBench;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.parallel.ParallelTest;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+/**
+ * Base class for ITs. The tests use Chrome driver to run integration tests on a
+ * headless Chrome.
+ */
+public abstract class AbstractViewTest extends ParallelTest {
+
+	private static final int SERVER_PORT = 8080;
+
+	private final String route;
+
+	protected static final Matcher<TestBenchElement> hasBeenUpgradedToCustomElement = new TypeSafeDiagnosingMatcher<TestBenchElement>() {
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("a custom element");
+		}
+
+		@Override
+		protected boolean matchesSafely(TestBenchElement item, Description mismatchDescription) {
+			String script = "let s=arguments[0].shadowRoot; return !!(s&&s.childElementCount)";
+			if (!item.getTagName().contains("-")) {
+				return true;
+			}
+
+			if ((Boolean) item.getCommandExecutor().executeScript(script, item)) {
+				return true;
+			} else {
+				mismatchDescription.appendText(item.getTagName() + " ");
+				mismatchDescription.appendDescriptionOf(is(not(this)));
+				return false;
+			}
+		}
+
+	};
+
+	@Rule
+	public ScreenshotOnFailureRule rule = new ScreenshotOnFailureRule(this, true);
+
+	protected AbstractViewTest(String route) {
+		this.route = route;
+	}
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.chromedriver().setup();
+	}
+
+	@Override
+	@Before
+	public void setup() throws Exception {
+		setDriver(TestBench.createDriver(new ChromeDriver()));
+		getDriver().get(getURL(route));
+	}
+
+	/**
+	 * Returns deployment host name concatenated with route.
+	 *
+	 * @return URL to route
+	 */
+	private static String getURL(String route) {
+		return String.format("http://%s:%d/%s", getDeploymentHostname(), SERVER_PORT, route);
+	}
+
+	/**
+	 * If running on CI, get the host name from environment variable HOSTNAME
+	 *
+	 * @return the host name
+	 */
+	private static String getDeploymentHostname() {
+		return "localhost";
+	}
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/ChipFieldElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/ChipFieldElement.java
@@ -1,0 +1,9 @@
+package com.flowingcode.vaadin.addons.chipfield.integration;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("paper-chip-input-autocomplete")
+public class ChipFieldElement extends TestBenchElement {
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/ViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/chipfield/integration/ViewIT.java
@@ -1,0 +1,19 @@
+package com.flowingcode.vaadin.addons.chipfield.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class ViewIT extends AbstractViewTest {
+
+	public ViewIT() {
+		super("it");
+	}
+
+    @Test
+	public void upgradedToCustomElement() {
+		ChipFieldElement chipfield = $(ChipFieldElement.class).first();
+		assertThat(chipfield, hasBeenUpgradedToCustomElement);
+    }
+
+}


### PR DESCRIPTION
Implement fixes required by #34. Also, add support for TestBench integration tests (which will be implemented in a separate branch)

fix: track additional items
Additional items were not returned by findItemByLabel
Close #35

fix: support adding additional items through setValue
If additional items are allowed, non-existing items are always tracked as additional items.
If additional items are not allowed, then setPresentationValue sanitizes the input by ignoring such items.
Close #36