### PR TITLE
build: upgrade javadoc plugin to 3.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,11 +311,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.11.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
-                                <phase>verify</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
@@ -323,9 +323,13 @@
                         </executions>
                         <configuration>
                             <quiet>true</quiet>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
+                            <failOnWarnings>false</failOnWarnings>
+                            <links>
+                                <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
+                            </links>
                         </configuration>
-                    </plugin>
+                     </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation generation with updated Javadoc plugin settings.
	- Added links to the Vaadin platform Javadoc for improved reference.

- **Bug Fixes**
	- Adjusted execution phases and configurations to ensure smoother builds.

- **Chores**
	- Updated various plugin versions for better performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->