### PR TITLE
Fix javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <failOnWarnings>false</failOnWarnings>
+                            <failOnWarnings>true</failOnWarnings>
                             <links>
                                 <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>

--- a/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/chipfield/ChipField.java
@@ -296,7 +296,7 @@ public class ChipField<T> extends AbstractField<ChipField<T>, List<T>>
     return getElement().getProperty("disabled", false);
   }
 
-  /** @deprecated use {@link #setReadOnly()} */
+  /** @deprecated use {@link #setReadOnly(boolean)} */
   @Deprecated
   public void setReadonly(boolean readonly) {
     setReadOnly(readonly);


### PR DESCRIPTION
Close #74 & #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Maven profile `v24` for enhanced dependency management and build configuration.
	- Added a new test dependency on `commons-demo` version `4.1.0`.

- **Improvements**
	- Updated Javadoc generation settings to fail on warnings, improving documentation reliability.

- **Deprecations**
	- Deprecated several methods in the `ChipField` class, directing users to updated method names for better clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->